### PR TITLE
Fixes issue 5, 6, 7, 8.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ zookeeper_version: 3.4.14
 zookeeper_url: http://archive.apache.org/dist/zookeeper/zookeeper-{{ zookeeper_version }}/apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
 
 client_port: 2181
+set_client_port_address: true
 init_limit: 5
 sync_limit: 2
 tick_time: 2000
@@ -14,10 +15,15 @@ zookeeper_max_client_connections: 60
 zookeeper_admin_server: false
 
 zookeeper_data_dir: /var/zookeeper
+zookeeper_data_log_dir: "{{ zookeeper_data_dir }}" # Zookeeper recommends you point this to a different device than the data dir
 zookeeper_log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{ zookeeper_version }}
 zookeeper_conf_dir: "{{ zookeeper_dir }}/conf"
 zookeeper_tarball_dir: /opt/src
+
+#If upgrading from Zookeeper 3.4 to 3.5.6+, and Zookeeper fails to boot with the message "No snapshot found, but there are log entries"
+#set the property below to true and deploy Zookeeper using your playbook. Once Zookeeper is running again, reset the property to false and rerun the playbook.
+snapshot_trust_empty: false 
 
 # Rolling file appender setttings
 zookeeper_rolling_log_file_max_size: 10MB

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,7 @@
     - "{{ zookeeper_data_dir }}"
     - "{{ zookeeper_log_dir }}"
     - "{{ zookeeper_conf_dir }}"
+    - "{{ zookeeper_data_log_dir | default([]) }}"
 
 - name: Write myid file
   tags: deploy
@@ -105,3 +106,29 @@
   systemd:
     name: zookeeper
     state: started
+
+- meta: flush_handlers #Ensure we restart if necessary before doing health checks
+    
+- name: Wait for zookeeper to be running
+  shell: 
+    chdir: "{{ zookeeper_dir }}/bin"
+    cmd: "bash zkServer.sh status"
+  retries: 12
+  delay: 5
+  register: zkServerLoop
+  until: "zkServerLoop.stdout.find('Mode: leader') != -1 or zkServerLoop.stdout.find('Mode: follower') != -1"
+  
+- name: Get zookeeper status
+  shell: 
+    chdir: "{{ zookeeper_dir }}/bin"
+    cmd: "bash zkServer.sh status"
+  register: zkStatus
+  
+- name: Verify that there is exactly one leader
+  fail:
+    msg: "The zookeeper cluster failed to reach quorum, the cluster had {{ leaderCount }} leaders, expected 1"
+  vars: 
+    leaderCount: "{{ ansible_play_hosts | map('extract', hostvars, 'zkStatus') | map(attribute='stdout') | select('search', '.*Mode: leader.*') | list | length }}"
+  when: (leaderCount | int) != 1
+  delegate_to: localhost
+  run_once: True

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -1,5 +1,8 @@
 tickTime={{ tick_time }}
 dataDir={{ zookeeper_data_dir }}
+{% if zookeeper_data_log_dir != zookeeper_data_dir %}
+dataLogDir={{ zookeeper_data_log_dir }}
+{% endif %}
 clientPort={{ client_port }}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
@@ -20,6 +23,12 @@ admin.enableServer=false
 admin.serverPort={{ zookeeper_admin_server_port }}
 {% endif %}
 
+{% if set_client_port_address is sameas true %}
+{% set my_host = zookeeper_hosts | selectattr('host', 'equalto', zookeeper_hosts_hostname) | first %}
+clientPortAddress = {{ my_host.ip | default(my_host.host) }}
+{% endif %}
+
+snapshot.trust.empty={{ snapshot_trust_empty | lower }}
 
 {% for server in zookeeper_hosts %}
 {% if server.host is defined %}


### PR DESCRIPTION
Set clientPortAddress by default, to the ip or hostname the Zookeepers also use to talk to each other.
Add an opt-out property in case people need ZK to bind to all interfaces instead of just that ip/hostname.

Add property for setting dataLogDir. Default it to be the same as the dataDir, and leave the zoo.cfg property unset
unless they are different.

Add property for working around https://issues.apache.org/jira/browse/ZOOKEEPER-3056.
I think it is fine to ask people to deploy ZK twice when doing this upgrade.

Added steps to verify that the ZK cluster looks healthy after deployment. These steps used to be manual.