### PR TITLE
Adds variable to skip zkStatus checks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,11 @@ zookeeper_hosts_hostname: "{{ inventory_hostname }}"
 zookeeper_hosts:
   - host: "{{ zookeeper_hosts_hostname }}" # the machine running
     id: 1
+
+
+# Skip the leader check, used for running against local only
+zookeeper_check_enabled: true
+
+# check zkStatus 20 times, delay 5 seconds between checks
+zookeeper_check_count: 20
+zookeeper_check_delay: 5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,29 +108,23 @@
     state: started
 
 - meta: flush_handlers #Ensure we restart if necessary before doing health checks
-    
-- name: Wait for zookeeper to be running
-  shell: 
-    chdir: "{{ zookeeper_dir }}/bin"
-    cmd: "bash zkServer.sh status"
-  retries: 12
-  delay: 5
-  register: zkServerLoop
-  until: "zkServerLoop.stdout.find('Mode: leader') != -1 or zkServerLoop.stdout.find('Mode: follower') != -1 or zkServerLoop.stdout.find('Mode: standalone') != -1"
-  
-- name: Get zookeeper status
-  shell: 
-    chdir: "{{ zookeeper_dir }}/bin"
-    cmd: "bash zkServer.sh status"
-  register: zkStatus
-  
-- name: Verify that there is exactly one leader
-  fail:
-    msg: "The zookeeper cluster failed to reach quorum, the cluster had {{ leaderCount }} leaders, expected 1"
-  vars: 
-    leaderCount: "{{ ansible_play_hosts | map('extract', hostvars, 'zkStatus') | map(attribute='stdout') | select('search', '.*Mode: leader.*') | list | length }}"
-    standAloneCount: "{{ ansible_play_hosts | map('extract', hostvars, 'zkStatus') | map(attribute='stdout') | select('search', '.*Mode: standalone.*') | list | length }}"
-  when: ((leaderCount | int) != 1) and
-        ((standAloneCount | int) != 1)
-  delegate_to: localhost
-  run_once: True
+
+# Check to see if zookeer reached quorum 
+# Skippable by setting zookeeper_check_enabled: false 
+- block: 
+    - name: Get zookeeper status and check leadership
+      shell: 
+        chdir: "{{ zookeeper_dir }}/bin"
+        cmd: "bash zkServer.sh status"
+      register: zookeeper_check_status
+    - name: Verify that there is exactly one leader
+      fail:
+        msg: "The zookeeper cluster failed to reach quorum, the cluster had {{ leaderCount }} leaders, expected 1"
+      vars: 
+        leader_count: "{{ ansible_play_hosts | map('extract', hostvars, 'zookeeper_status') | map(attribute='stdout') | select('search', '.*Mode: leader.*') | list | length }}"
+        stand_alone_count: "{{ ansible_play_hosts | map('extract', hostvars, 'zookeeper_status') | map(attribute='stdout') | select('search', '.*Mode: standalone.*') | list | length }}"
+      when: ((leader_count | int) != 1) and
+            ((stand_alone_count | int) != 1)
+      delegate_to: localhost
+      run_once: True
+  when: zookeeper_check_enabled == true


### PR DESCRIPTION
Allows the zKstatus check to be skipped for some use cases.
Renames variables that were camelCase
Adds variables to configure zookeeper starting checks